### PR TITLE
Include requirements.txt in sdists

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,6 +4,7 @@ include setupbase.py
 
 include LICENSE
 include README.rst
+include requirements.txt
 
 # Documentation
 graft docs


### PR DESCRIPTION
sdists cannot be installed without it